### PR TITLE
Change CreatEd to CreatED as we've styled it elsewhere

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,7 +26,7 @@ social:
 
 # This is Search Engine Optimization. It'll help your website look better on search.
 seo:
-  title:                "CreatEd | 5-7 April 2018"
+  title:                "CreatED | 5-7 April 2018"
   description:          "24-hour hardware hackathon in Edinburgh"
   image:                "https://createdhack.github.io/images/logo.png"
 
@@ -37,7 +37,7 @@ organiser:
 
 # Event information.
 event:
-  name:                 "CreatEd 2018"
+  name:                 "CreatED 2018"
   description:          "24-hour hardware hackathon in Edinburgh"
   date_set:             false
   date:                 "5-7 April 2018"
@@ -60,7 +60,7 @@ event:
 
   about:
     description:        >
-      CreatEd is a 24 hour hardware hackathon coming to Edinburgh this April.{::nomarkdown}<br />{:/}
+      CreatED is a 24 hour hardware hackathon coming to Edinburgh this April.{::nomarkdown}<br />{:/}
       It'll bring together students for a fun weekend of invention, hacking, and learning.{::nomarkdown}<br />{:/}
       Brought to you [The University of Edinburgh Embedded and Robotics Society](http://ears-edi.com/).
       {::nomarkdown}<br />{:/}{::nomarkdown}<br />{:/}


### PR DESCRIPTION
We've told potential sponsors and MLH that we are CreatED so this is just to bring the website and marketing in line. Could you sort this elsewhere?

(And tell me if this is everything on the site)